### PR TITLE
Adding support for mPDF7.

### DIFF
--- a/PDFResponse.php
+++ b/PDFResponse.php
@@ -14,6 +14,7 @@
 
 namespace PdfResponse;
 
+use Mpdf\Mpdf;
 use Nette\Utils\Strings;
 use Nette\Object;
 use Nette\Http\IRequest;
@@ -258,7 +259,8 @@ class PdfResponse extends Object implements \Nette\Application\IResponse {
 	}
 
 	/**
-	 * @param  mixed  renderable variable
+	 * PdfResponse constructor.
+	 * @param $source
 	 */
 	public function __construct($source) {
 		$this->createMPDF = array($this, "createMPDF");
@@ -400,10 +402,10 @@ class PdfResponse extends Object implements \Nette\Application\IResponse {
 	 * @return mPDFExtended
 	 */
 	public function getMPDF() {
-		if(!$this->mPDF instanceof \mPDF) {
+		if(!$this->mPDF instanceof Mpdf) {
 			if(Callback::check($this->createMPDF)) {
 				$mpdf = Callback::invoke($this->createMPDF);
-				if(!($mpdf instanceof \mPDF)) {
+				if(!($mpdf instanceof Mpdf)) {
 					throw new \Nette\InvalidStateException("Callback function createMPDF must return mPDF object!");
 				}
 				$this->mPDF = $mpdf;
@@ -414,31 +416,27 @@ class PdfResponse extends Object implements \Nette\Application\IResponse {
 	}
 
 
-
 	/**
 	 * Creates and returns mPDF object
-	 * @param PDFResponse $response
 	 * @return mPDFExtended
 	 */
 	public function createMPDF() {
 		$margins = $this->getMargins();
 
-		//  [ float $margin_header , float $margin_footer [, string $orientation ]]]]]])
-		$mpdf = new mPDFExtended(
-			'utf-8',            // string $codepage
-			$this->pageFormat,  // mixed $format
-			'',                 // float $default_font_size
-			'',                 // string $default_font
-			$margins["left"],   // float $margin_left
-			$margins["right"],  // float $margin_right
-			$margins["top"],    // float $margin_top
-			$margins["bottom"], // float $margin_bottom
-			$margins["header"], // float $margin_header
-			$margins["footer"], // float $margin_footer
-			$this->pageOrientation
-		);
+		$mpdf = new mPDFExtended([
+			'mode' => 'utf-8',
+			'format' => $this->pageFormat,
+			'default_font_size' => '',
+			'default_font' => '',
+			'margin_left' => $margins["left"],
+			'margin_right' => $margins["right"],
+			'margin_top' => $margins["top"],
+			'margin_bottom' => $margins["bottom"],
+			'margin_header' => $margins["header"],
+			'margin_footer' => $margins["footer"],
+			'orientation' => $this->pageOrientation,
+		]);
 
 		return $mpdf;
 	}
-
 }

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,6 @@
 		"nette/utils": ">= 2.2",
 		"nette/http": ">= 2.2",
 		"nette/application": ">= 2.2",
-		"mpdf/mpdf": ">= 5.0"
+		"mpdf/mpdf": "^7.0-dev"
 	}
 }

--- a/mPDFExtended.php
+++ b/mPDFExtended.php
@@ -14,12 +14,14 @@
 
 namespace PdfResponse;
 
+use Mpdf\Mpdf;
+
 /**
  * Extended version of mPDF
  *  - added support for JavaScript
  *  - shortcut for opening print dialog
  */
-class mPDFExtended extends \mPDF {
+class mPDFExtended extends Mpdf {
 
 	// <editor-fold defaultstate="collapsed" desc="JavaScript support - use $mpf->IncludeJS($yourScript)">
 	var $javascript="";
@@ -63,4 +65,4 @@ class mPDFExtended extends \mPDF {
 		$this->IncludeJS("print();");
 	}
 
-} 
+}


### PR DESCRIPTION
Older versions of mPDF (including 6.*) tended to throw notices and errors
in some cases when used with PHP 7.1. mPDF7 is fully supporting PHP 7.1,
but added some breaking changes, mostly:

  - namespaced class
  - changed constructor

This commits brings a breaking change adding support for mPDF7 and also
dropping support for any older version of mPDF.

#19 