### PR TITLE
Adding support for configurable tempDir path.

### DIFF
--- a/PDFResponse.php
+++ b/PDFResponse.php
@@ -159,6 +159,14 @@ class PdfResponse extends Object implements \Nette\Application\IResponse {
 	public $displayLayout = "continuous";
 
 	/**
+	 * This parameter specifie the directory to be used as a temp dir when generating PDF content.<br/>
+	 * If it is empty, mPDF default value is used.
+	 *
+	 * @var string
+	 */
+	public $tempDir = "";
+
+	/**
 	 * Before document output starts
 	 * @var callback
 	 */
@@ -422,8 +430,7 @@ class PdfResponse extends Object implements \Nette\Application\IResponse {
 	 */
 	public function createMPDF() {
 		$margins = $this->getMargins();
-
-		$mpdf = new mPDFExtended([
+		$config = [
 			'mode' => 'utf-8',
 			'format' => $this->pageFormat,
 			'default_font_size' => '',
@@ -435,8 +442,12 @@ class PdfResponse extends Object implements \Nette\Application\IResponse {
 			'margin_header' => $margins["header"],
 			'margin_footer' => $margins["footer"],
 			'orientation' => $this->pageOrientation,
-		]);
+		];
+		if (!empty($this->tempDir)) {
+			$config['tempDir'] = $this->tempDir;
+		}
 
+		$mpdf = new mPDFExtended($config);
 		return $mpdf;
 	}
 }

--- a/PDFResponse.php
+++ b/PDFResponse.php
@@ -162,9 +162,9 @@ class PdfResponse extends Object implements \Nette\Application\IResponse {
 	 * This parameter specifie the directory to be used as a temp dir when generating PDF content.<br/>
 	 * If it is empty, mPDF default value is used.
 	 *
-	 * @var string
+	 * @var string|null
 	 */
-	public $tempDir = "";
+	public $tempDir = null;
 
 	/**
 	 * Before document output starts
@@ -443,11 +443,10 @@ class PdfResponse extends Object implements \Nette\Application\IResponse {
 			'margin_footer' => $margins["footer"],
 			'orientation' => $this->pageOrientation,
 		];
-		if (!empty($this->tempDir)) {
+		if ($this->tempDir !== null) {
 			$config['tempDir'] = $this->tempDir;
 		}
 
-		$mpdf = new mPDFExtended($config);
-		return $mpdf;
+		return new mPDFExtended($config);
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,6 @@
 		"nette/utils": ">= 2.4",
 		"nette/http": ">= 2.4",
 		"nette/application": ">= 2.4",
-		"mpdf/mpdf": "^7.0-beta2"
+		"mpdf/mpdf": "^7.0.0"
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,6 @@
 		"nette/utils": ">= 2.2",
 		"nette/http": ">= 2.2",
 		"nette/application": ">= 2.2",
-		"mpdf/mpdf": "^7.0-dev"
+		"mpdf/mpdf": "^7.0-beta2"
 	}
 }


### PR DESCRIPTION
In older version of mPDF, PHP constants `_MPDF_TEMP_PATH` and `_MPDF_TTFONTDATAPATH` were used to determine temp dirs. Since mPDF7 it's a configuration option. If it's not present, it's defaulting to `__DIR__ . '/../../tmp`. 

When using `PdfResponse` I currently have no option how to affect this.

For that reason I've added a new property to the `PdfResponse` class called `$tempDir` which is passed to the library if it's not empty.
