### PR TITLE
Add imageVars, fixes incompatibility with mpdf\strict trait

### DIFF
--- a/src/PdfResponse.php
+++ b/src/PdfResponse.php
@@ -380,7 +380,7 @@ class PdfResponse implements \Nette\Application\IResponse {
 			if($data === false) continue;
 
 			$propertyName = 'base64Image' .$i;
-			$mpdf->$propertyName = $data;
+			$mpdf->imageVars[$propertyName] = $data;
 			$element->src = 'var:' .$propertyName;
 			$i++;
 		}


### PR DESCRIPTION
If you add image to pdf script PdfResponse tries to add it right to mpdf variables. This is not possible because of class mpdf/strict.
This issue is mentioned here https://mpdf.github.io/what-else-can-i-do/images.html#image-data-as-a-variable

 