### PR TITLE
Remove broken base64 encoded images workaround

### DIFF
--- a/src/PdfResponse.php
+++ b/src/PdfResponse.php
@@ -362,30 +362,6 @@ class PdfResponse implements \Nette\Application\IResponse {
 			$mode = 0; // Parse all: HTML + CSS
 		}
 
-		// Support for base64 encoded images - workaround
-		$parsedHtml = $this->createDom();
-		$parsedHtml->loadStr($html);
-		$i = 1000;
-		foreach($parsedHtml->find('img') AS $element) {
-			$boundary1 = 'data:';
-			$pos1 = strlen($boundary1);
-			if(!substr($element->src,0,$pos1) == $boundary1) continue;
-			$pos2 = strpos($element->src, ';',$pos1);
-			if($pos2 === false) continue;
-			$mime = substr($element->src, $pos1, $pos2-$pos1);
-			$boundary = 'base64,';
-			$base64 = substr($element->src, $pos2+strlen($boundary)+1);
-
-			$data = base64_decode($base64);
-			if($data === false) continue;
-
-			$propertyName = 'base64Image' .$i;
-			$mpdf->$propertyName = $data;
-			$element->src = 'var:' .$propertyName;
-			$i++;
-		}
-		$html = $parsedHtml->__toString();
-
 		Utils::tryCall($this->onBeforeWrite);
 
 		// Add content


### PR DESCRIPTION
The workaround doesn't work for the latest (8.0.6) version of mPDF, since Mpdf class does not support setting undefined properties (because of newly added [Strict trait](https://github.com/mpdf/mpdf/blob/v8.0.6/src/Mpdf.php#L39)). This code snippet from the workaround:

```
$propertyName = 'base64Image' .$i;
$mpdf->$propertyName = $data;
```

will end up with `Cannot write to an undeclared property Mpdf\Mpdf::$base64Image` exception message.

However, workaround is not required now since mPDF supports base64 encoded images by default.